### PR TITLE
fix: use ipify for public ip lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ def update_ip():
     # Try to get the IP and update the data on No-IP
     try:
         # Get the public ip
-        r = requests.get('http://ipv4.iplocation.net')
+        r = requests.get('https://api.ipify.org?format=json')
         ip = r.json()['ip']
         # Update
         r = requests.get("https://{}:{}@dynupdate.no-ip.com/nic/update?hostname={}&myip={}".format(USER, PASSWORD, HOSTNAME, ip))


### PR DESCRIPTION
## Summary

Replace the broken `ipv4.iplocation.net` endpoint with `api.ipify.org` for public IP lookup, which returns a reliable JSON response.

## Changes

- **app.py** — Changed the public IP lookup URL from `http://ipv4.iplocation.net` to `https://api.ipify.org?format=json` and parse the `ip` field from the JSON response.

## Test plan

- [x] Run `python app.py` and verify the IP is successfully retrieved and sent to No-IP
- [x] Confirm the application no longer hangs on the old `ipv4.iplocation.net` endpoint