### PR TITLE
ci: group dependabot updates by semver level and skip majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      github-actions-major:
+        update-types:
+          - 'major'
+      github-actions-minor:
+        update-types:
+          - 'minor'
+      github-actions-patch:
+        update-types:
+          - 'patch'
 
   # Maintain dependencies for Python
   - package-ecosystem: 'pip'
@@ -20,3 +30,13 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      pip-minor:
+        update-types:
+          - 'minor'
+      pip-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary
Configure Dependabot to open grouped PRs instead of one PR per dependency, and stop opening PRs for major version updates on pip so breaking upgrades are handled manually. GitHub Actions majors stay enabled (Actions are tagged with major-only versions, so ignoring them would disable all Actions updates) and arrive as a grouped PR.

Same change as derogab/poop-cleaner#78, adapted for this repo's ecosystems.

## Changes
- Add `groups` to both ecosystems: minor bumps are combined into one PR and patch bumps into another, per ecosystem
- Add a `github-actions-major` group so Actions major bumps arrive as a single grouped PR instead of one PR each
- Add an `ignore` rule (`dependency-name: '*'` + `version-update:semver-major`) to pip so no major-version PRs are opened

## Test plan
- [x] YAML syntax validated locally
- [ ] After merge, wait for the next monthly Dependabot run and confirm PRs arrive grouped as `pip-minor` / `pip-patch` and `github-actions-*`, with no pip major bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group Dependabot updates by semver and stop opening `pip` major bumps to reduce PR noise and handle breaking changes manually. `github-actions` majors remain enabled and arrive as one grouped PR.

- **Dependencies**
  - Group `github-actions` updates into `github-actions-major`, `github-actions-minor`, `github-actions-patch`.
  - Group `pip` updates into `pip-minor` and `pip-patch`.
  - Ignore `pip` majors via `dependency-name: '*'` with `update-types: ['version-update:semver-major']`.

<sup>Written for commit 444a4b4b1e949fc82197c37dc85bab14efef76a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/derogab/no-ip-updater/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

